### PR TITLE
Monad Special Ops

### DIFF
--- a/Operators.swift
+++ b/Operators.swift
@@ -50,8 +50,32 @@ infix operator <^> {
 	precedence 140
 }
 
+/// "Replace" | Maps all the values encapsulated by a functor to a user-specified constant.
+infix operator <% {
+	associativity left
+	precedence 140
+}
+
 /// Ap | Applies a function encapsulated by a functor to the value encapsulated by another functor.
 infix operator <*> {
+	associativity left
+	precedence 140
+}
+
+/// Sequence Right | Disregards the Functor on the Left.
+///
+/// Default definition:
+///		`const(id) <^> a <*> b`
+infix operator *> {
+	associativity left
+	precedence 140
+}
+
+/// Sequence Left | Disregards the Functor on the Right.
+///
+/// Default definition:
+///		`const <^> a <*> b`
+infix operator <* {
 	associativity left
 	precedence 140
 }
@@ -60,6 +84,25 @@ infix operator <*> {
 /// left to a function on the right yielding a new monad.
 infix operator >>- {
 	associativity left
+	precedence 110
+}
+
+/// Bind Backwards | Composes two monadic actions by passing the value inside the monad on the 
+/// right to the funciton on the left.
+infix operator -<< {
+	associativity right
+	precedence 110
+}
+
+/// Left-to-Right Kleisli |
+infix operator >>->> {
+	associativity right
+	precedence 110
+}
+
+/// Right-to-Left Kleisli |
+infix operator <<-<< {
+	associativity right
 	precedence 110
 }
 

--- a/Operators.swift
+++ b/Operators.swift
@@ -7,7 +7,7 @@
 //  Released under the MIT License.
 //
 
-/// MARK: Combinators
+// Mark: Combinators
 
 /// Compose | Applies one function to the result of another function to produce a third function.
 infix operator • {
@@ -42,7 +42,7 @@ infix operator |*| {
 }
 
 
-/// MARK: Control.*
+// Mark: Control.*
 
 /// Fmap | Maps a function over the value encapsulated by a functor.
 infix operator <^> {
@@ -82,7 +82,7 @@ infix operator <!> {
 	precedence 140
 }
 
-/// MARK: Data.Result
+// Mark: Data.Result
 
 /// From | Creates a Result given a function that can possibly fail with an error.
 infix operator !! {
@@ -90,7 +90,7 @@ infix operator !! {
 	precedence 120
 }
 
-/// MARK: Data.Monoid
+// Mark: Data.Monoid
 
 /// Append | Alias for a Semigroup's operation.
 infix operator <> {
@@ -98,7 +98,7 @@ infix operator <> {
 	precedence 160
 }
 
-/// MARK: Control.Category
+// Mark: Control.Category
 
 /// Right-to-Left Composition | Composes two categories to form a new category with the source of
 /// the second category and the target of the first category.
@@ -118,7 +118,7 @@ infix operator >>> {
 	precedence 110
 }
 
-/// MARK: Control.Arrow
+// Mark: Control.Arrow
 
 /// Split | Splits two computations and combines the result into one Arrow yielding a tuple of
 /// the result of each side.
@@ -135,7 +135,7 @@ infix operator &&& {
 	precedence 130
 }
 
-/// MARK: Control.Arrow.Choice
+// Mark: Control.Arrow.Choice
 
 /// Splat | Splits two computations and combines the results into Eithers on the left and right.
 infix operator +++ {
@@ -150,7 +150,7 @@ infix operator ||| {
 	precedence 120
 }
 
-/// MARK: Control.Arrow.Plus
+// Mark: Control.Arrow.Plus
 
 /// Op | Combines two ArrowZero monoids.
 infix operator <+> {
@@ -158,7 +158,7 @@ infix operator <+> {
 	precedence 150
 }
 
-/// MARK: Data.JSON
+// Mark: Data.JSON
 
 /// Retrieve | Retrieves a value from a dictionary of JSON values using a given keypath.
 ///
@@ -180,7 +180,7 @@ infix operator <! {
 	precedence 150
 }
 
-/// MARK: Data.Set
+// Mark: Data.Set
 
 /// Intersection | Returns the intersection of two sets.
 infix operator ∩ {}

--- a/Operators.swift
+++ b/Operators.swift
@@ -50,11 +50,18 @@ infix operator <^> {
 	precedence 140
 }
 
-/// "Replace" | Maps all the values encapsulated by a functor to a user-specified constant.
-infix operator <% {
+/// Replace | Maps all the values encapsulated by a functor to a user-specified constant.
+infix operator <^ {
 	associativity left
 	precedence 140
 }
+
+/// Replace Backwards | Maps all the values encapsulated by a functor to a user-specified constant.
+infix operator ^> {
+associativity left
+precedence 140
+}
+
 
 /// Ap | Applies a function encapsulated by a functor to the value encapsulated by another functor.
 infix operator <*> {

--- a/Operators.swift
+++ b/Operators.swift
@@ -58,8 +58,8 @@ infix operator <^ {
 
 /// Replace Backwards | Maps all the values encapsulated by a functor to a user-specified constant.
 infix operator ^> {
-associativity left
-precedence 140
+	associativity left
+	precedence 140
 }
 
 

--- a/Operators.swift
+++ b/Operators.swift
@@ -7,7 +7,7 @@
 //  Released under the MIT License.
 //
 
-// Mark: Combinators
+// MARK: Combinators
 
 /// Compose | Applies one function to the result of another function to produce a third function.
 infix operator • {
@@ -42,7 +42,7 @@ infix operator |*| {
 }
 
 
-// Mark: Control.*
+// MARK: Control.*
 
 /// Fmap | Maps a function over the value encapsulated by a functor.
 infix operator <^> {
@@ -82,7 +82,7 @@ infix operator <!> {
 	precedence 140
 }
 
-// Mark: Data.Result
+// MARK: Data.Result
 
 /// From | Creates a Result given a function that can possibly fail with an error.
 infix operator !! {
@@ -90,7 +90,7 @@ infix operator !! {
 	precedence 120
 }
 
-// Mark: Data.Monoid
+// MARK: Data.Monoid
 
 /// Append | Alias for a Semigroup's operation.
 infix operator <> {
@@ -98,7 +98,7 @@ infix operator <> {
 	precedence 160
 }
 
-// Mark: Control.Category
+// MARK: Control.Category
 
 /// Right-to-Left Composition | Composes two categories to form a new category with the source of
 /// the second category and the target of the first category.
@@ -118,7 +118,7 @@ infix operator >>> {
 	precedence 110
 }
 
-// Mark: Control.Arrow
+// MARK: Control.Arrow
 
 /// Split | Splits two computations and combines the result into one Arrow yielding a tuple of
 /// the result of each side.
@@ -135,7 +135,7 @@ infix operator &&& {
 	precedence 130
 }
 
-// Mark: Control.Arrow.Choice
+// MARK: Control.Arrow.Choice
 
 /// Splat | Splits two computations and combines the results into Eithers on the left and right.
 infix operator +++ {
@@ -150,7 +150,7 @@ infix operator ||| {
 	precedence 120
 }
 
-// Mark: Control.Arrow.Plus
+// MARK: Control.Arrow.Plus
 
 /// Op | Combines two ArrowZero monoids.
 infix operator <+> {
@@ -158,7 +158,7 @@ infix operator <+> {
 	precedence 150
 }
 
-// Mark: Data.JSON
+// MARK: Data.JSON
 
 /// Retrieve | Retrieves a value from a dictionary of JSON values using a given keypath.
 ///
@@ -180,7 +180,7 @@ infix operator <! {
 	precedence 150
 }
 
-// Mark: Data.Set
+// MARK: Data.Set
 
 /// Intersection | Returns the intersection of two sets.
 infix operator ∩ {}


### PR DESCRIPTION
Adds several new operators to aid in the solution to typelift/Swiftz#143
- `<^`/`^>` “Replace”
- `<*`/`*>` Sequence Left/RIght
- `-<<` Bind Backwards
- `>>->>`/`<<-<<` Kleisli composition from Aquifer
