### PR TITLE
[missing-operators] adding missing prefix and postfix operators

### DIFF
--- a/Operators.swift
+++ b/Operators.swift
@@ -237,3 +237,29 @@ infix operator ∩ {}
 
 /// Union | Returns the union of two sets.
 infix operator ∪ {}
+
+// MARK: Prefix/Postfix
+
+prefix operator • {}
+postfix operator • {}
+
+prefix operator § {}
+postfix operator § {}
+
+prefix operator <| {}
+postfix operator <| {}
+
+prefix operator |> {}
+postfix operator |> {}
+
+prefix operator <^> {}
+postfix operator <^> {}
+
+prefix operator <!> {}
+postfix operator <!> {}
+
+prefix operator <*> {}
+postfix operator <*> {}
+
+prefix operator >>- {}
+postfix operator >>- {}


### PR DESCRIPTION
Prevents errors in Swiftz like these

![screen shot 2015-08-25 at 8 57 35 am](https://cloud.githubusercontent.com/assets/4276518/9487995/559c23dc-4b8b-11e5-9b1a-c4e4374656e2.png)
